### PR TITLE
fixed scenario when mml=1 and mmwp=0 in mac mode

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -283,7 +283,9 @@ reg_t mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
     base = tor;
   }
 
-  return ((mode == PRV_M) && !(proc->state.mseccfg & MSECCFG_MMWP));
+  return ((mode == PRV_M) &&
+          !(proc->state.mseccfg & MSECCFG_MMWP) &&
+          !(type == FETCH && (proc->state.mseccfg & MSECCFG_MML)));
 }
 
 reg_t mmu_t::pmp_homogeneous(reg_t addr, reg_t len)

--- a/tests/mseccfg/gengen_src/gen_pmp_test.cc
+++ b/tests/mseccfg/gengen_src/gen_pmp_test.cc
@@ -117,6 +117,8 @@ main()
         if (u_mode == 1 || mmwp) { // mmwp to against non-match
             rw_err = 1;
             x_err = 1;
+        } else if (mml == 1) {
+            x_err = 1;
         }
     }
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match0_mmwp0_mml1.c
@@ -73,7 +73,7 @@ void exit(int code);
 static const unsigned long expected_rw_fail = 0;
 static unsigned actual_rw_fail = 0;
 
-static const unsigned long expected_x_fail = 0;
+static const unsigned long expected_x_fail = 1;
 static unsigned actual_x_fail = 0;
 static void checkTestResult(void);
 


### PR DESCRIPTION
Hi @soberl, for the first issue mentioned in - https://github.com/joxie/riscv-isa-sim/issues/1 - I have created a PR containing the fix for scenario when mml=1 and mmwp=0 in machine mode which should potentially deny execute accesses according to epmp spec.

I have also generated the tests (changes can be seen in this PR).

Can you please review these changes?