### PR TITLE
changed addr of MSECCFG csr to 0x747, regen tests

### DIFF
--- a/riscv/encoding.h
+++ b/riscv/encoding.h
@@ -1962,7 +1962,7 @@
 #define CSR_MIP 0x344
 #define CSR_MTINST 0x34a
 #define CSR_MTVAL2 0x34b
-#define CSR_MSECCFG 0x390
+#define CSR_MSECCFG 0x747
 #define CSR_PMPCFG0 0x3a0
 #define CSR_PMPCFG1 0x3a1
 #define CSR_PMPCFG2 0x3a2

--- a/tests/mseccfg/gengen_src/Makefile
+++ b/tests/mseccfg/gengen_src/Makefile
@@ -11,7 +11,7 @@ default:
 gen:
 	-rm -rf outputs; mkdir outputs
 	g++ -g3 -O2 gen_pmp_test.cc -o a.out
-	a.out
+	./a.out
 	
 clean: 
 	rm -rf test_*.h a.out outputs/*

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp0_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb0_mmwp1_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp0_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock00_rlb1_mmwp1_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp0_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb0_mmwp1_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp0_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock01_rlb1_mmwp1_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp0_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb0_mmwp1_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp0_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml0_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_11.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_11.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_12.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_12.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_13.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_13.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_14.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_14.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_15.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_15.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_16.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_16.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_17.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_pmp_17.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_00.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_00.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_01.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_01.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_02.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_02.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_03.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_03.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (0 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_04.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_04.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_05.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_05.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (0 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_06.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_06.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (0 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_07.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_csr_1_lock10_rlb1_mmwp1_mml1_sec_07.c
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (1 ? MSECCFG_RLB : 0) 
             | (1 ? MSECCFG_MML : 0) 
             | (1 ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x0_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw00_x1_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x0_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw10_x1_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x0_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u0_rw11_x1_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x0_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw00_x1_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x0_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw10_x1_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x0_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l0_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match0_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match0_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match0_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match0_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match0_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match0_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match0_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match0_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match1_mmwp0_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match1_mmwp0_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match1_mmwp0_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match1_mmwp0_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (0 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match1_mmwp1_mml0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match1_mmwp1_mml0.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (0 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match1_mmwp1_mml1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_1_u1_rw11_x1_l1_match1_mmwp1_mml1.c
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (1 ? MSECCFG_MML : 0) | (1 ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl0_typex0_umode0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl0_typex0_umode0.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl0_typex0_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl0_typex0_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl0_typex1_umode0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl0_typex1_umode0.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl0_typex1_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl0_typex1_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl1_typex0_umode0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl1_typex0_umode0.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl1_typex0_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl1_typex0_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl1_typex1_umode0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl1_typex1_umode0.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl1_typex1_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x0_cfgl1_typex1_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl0_typex0_umode0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl0_typex0_umode0.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl0_typex0_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl0_typex0_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl0_typex1_umode0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl0_typex1_umode0.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl0_typex1_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl0_typex1_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl1_typex0_umode0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl1_typex0_umode0.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl1_typex0_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl1_typex0_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl1_typex1_umode0.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl1_typex1_umode0.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl1_typex1_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r0_x1_cfgl1_typex1_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x0_cfgl0_typex0_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x0_cfgl0_typex0_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x0_cfgl0_typex1_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x0_cfgl0_typex1_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x0_cfgl1_typex0_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x0_cfgl1_typex0_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x0_cfgl1_typex1_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x0_cfgl1_typex1_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x1_cfgl0_typex0_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x1_cfgl0_typex0_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x1_cfgl0_typex1_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x1_cfgl0_typex1_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x1_cfgl1_typex0_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x1_cfgl1_typex0_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x1_cfgl1_typex1_umode1.c
+++ b/tests/mseccfg/gengen_src/outputs/test_pmp_ok_share_1_r1_x1_cfgl1_typex1_umode1.c
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM

--- a/tests/mseccfg/gengen_src/test_pmp_csr_1.cc_skel
+++ b/tests/mseccfg/gengen_src/test_pmp_csr_1.cc_skel
@@ -123,7 +123,7 @@ static void set_cfg() {
     /*
      * set MSECCFG_RLB to avoid locked at start
      */
-    asm volatile ("csrs 0x390, %0 \n"::"r"(MSECCFG_RLB));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(MSECCFG_RLB));
     asm volatile ("nop");
 #endif
     
@@ -195,7 +195,7 @@ static void set_cfg() {
     const unsigned seccfg_bits = (@lock_bypass:int@ ? MSECCFG_RLB : 0) 
             | (@pre_sec_mml:int@ ? MSECCFG_MML : 0) 
             | (@pre_sec_mmwp:int@ ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrw 0x747, %0 \n"::"r"(seccfg_bits));
     
 //------------------------Test target
     asm volatile ("nop");
@@ -255,8 +255,8 @@ static void set_cfg() {
     wval = (@sec_rlb:int@ ? MSECCFG_RLB : 0) 
             | (@sec_mml:int@ ? MSECCFG_MML : 0) 
             | (@sec_mmwp:int@ ? MSECCFG_MMWP : 0);
-    asm volatile ("csrw 0x390, %1 \n"
-                "\tcsrr %0, 0x390 \n"
+    asm volatile ("csrw 0x747, %1 \n"
+                "\tcsrr %0, 0x747 \n"
             : "=r"(rval)
             : "r"(wval)
               : "memory");

--- a/tests/mseccfg/gengen_src/test_pmp_ok_1.cc_skel
+++ b/tests/mseccfg/gengen_src/test_pmp_ok_1.cc_skel
@@ -193,7 +193,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -268,7 +268,7 @@ static void set_cfg() {
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = (@set_sec_mml:int@ ? MSECCFG_MML : 0) | (@set_sec_mmwp:int@ ? MSECCFG_MMWP : 0);
     if (seccfg_bits) {
-        asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+        asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     }
     
     // currently dummy since tlb flushed when set_csr on mseccfg

--- a/tests/mseccfg/gengen_src/test_pmp_ok_share_1.cc_skel
+++ b/tests/mseccfg/gengen_src/test_pmp_ok_share_1.cc_skel
@@ -155,7 +155,7 @@ static void set_cfg() {
      * set MSECCFG_RLB to avoid locked
      */
     unsigned rlb_value = MSECCFG_RLB;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(rlb_value));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(rlb_value));
 #endif
     
     /*
@@ -202,7 +202,7 @@ static void set_cfg() {
                 : "memory");
     // set proc->state.mseccfg, for MML/MMWP
     const unsigned seccfg_bits = MSECCFG_MML | MSECCFG_MMWP;
-    asm volatile ("csrs 0x390, %0 \n"::"r"(seccfg_bits));
+    asm volatile ("csrs 0x747, %0 \n"::"r"(seccfg_bits));
     
     // after set MML, RW=01 is possible
     cfg0 |= (PMP_R | PMP_W | PMP_X | PMP_TOR) << 24;    // for U_MEM


### PR DESCRIPTION
Hi @soberl,

The ePMP spec has been updated at : [Updated ePMP Spec](https://github.com/riscv/riscv-tee/blob/d2f9066db019772c124179b67390630f4429383b/Smepmp/Smepmp.pdf) and the MSECCFG csr address has been changed from 0x390 to 0x747. I've updated and regenerated the tests with the new address.

Another small change is that i've added is to add a directory qualifier to [the Makefile in tests/mseccfg/gengen_src](https://github.com/joxie/riscv-isa-sim/blob/d9b2fb616bd53760ddf9d670364ef30697c5045b/tests/mseccfg/gengen_src/Makefile#L14). a.out wouldn't run otherwise on some shells.